### PR TITLE
fix: 修复外部样式引用丢失问题

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,16 +118,24 @@ const generateHtmlCode = (
 // 根据compiler组合成style标签字符串代码
 const generateStyleCode = (styles: any[]) =>
   styles.reduce((str, item, _i) => {
-    return (str += `<style ${item.lang ? "lang='" + item.lang + "'" : ''} ${
-      item.scoped ? "scoped='" + item.scoped + "'" : ''
-    }>
-		${item.content}
-	</style>`);
+    // 构建属性字符串
+    let attrs = '';
+    if (item.lang) attrs += ` lang='${item.lang}'`;
+    if (item.scoped) attrs += ` scoped`; // scoped 是布尔属性，不需要值
+    if (item.src) attrs += ` src='${item.src}'`; // 关键：添加对 src 属性的支持
+
+    // 根据是否有 src 属性来决定如何生成标签
+    if (item.src) {
+      // 如果有 src，则生成自闭合标签或空标签，Vite 会根据 src 去加载文件
+      return str + `<style${attrs}></style>\n`;
+    } else {
+      // 如果没有 src，则将 content 作为标签体
+      return str + `<style${attrs}>\n${item.content}\n</style>\n`;
+    }
   }, '');
 
 // 根据compiler组合成script标签字符串代码
 const generateScriptCode = (script: SFCScriptBlock) => {
-  
   return `<script ${script?.lang ? `lang='${script?.lang}'` : ''} ${script.setup ? 'setup' : null}>
   ${script.content}
 </script>`;


### PR DESCRIPTION
当vue文件中存在外部样式文件引入时会出现样式丢失，通过ai检查发现.utils文件中的generateStyleCode方法存在问题，故修复

```
// 根据compiler组合成style标签字符串代码
const generateStyleCode = (styles: any[]) =>
  styles.reduce((str, item, _i) => {
    return (str += `<style ${item.lang ? "lang='" + item.lang + "'" : ''} ${
      item.scoped ? "scoped='" + item.scoped + "'" : ''
    }>
		${item.content}
	</style>`);
  }, '');
```
这个函数在生成 <style> 标签时，只做了三件事：

检查并添加 lang 属性。
检查并添加 scoped 属性。
直接将 item.content 作为标签体内容插入。
它完全忽略了 item.src 这个属性！

为什么会这样？
在 Vue 单文件组件中，<style> 标签有两种常见写法：

```
<style scoped lang="scss">
.my-class { color: red; }
</style>
```
对于这种写法，@vue/compiler-sfc 解析后，descriptor.styles 数组中的对应项会是：

```
{
  content: ".my-class { color: red; }",
  lang: "scss",
  scoped: true,
  src: undefined // 或者没有 src 字段
}
```
这种情况下，generateStyleCode 可以正常工作，因为它直接输出了 content。
外部引用样式：
```
<style scoped lang="scss" src="./index.scss"></style>
```
对于这种写法，@vue/compiler-sfc 解析后，descriptor.styles 数组中的对应项会是：
```
{
  content: "", // 或者 undefined，因为内容是从外部文件加载的
  lang: "scss",
  scoped: true,
  src: "./index.scss" // 关键！路径在这里
}
```
在这种情况下，generateStyleCode 会生成如下代码：
```
<style lang='scss' scoped='true'>
</style>
```
它生成了一个空的 <style> 标签，src="./index.scss" 这个关键属性完全丢失了！这就是为什么您的外部样式会“丢失”。
解决方案
您需要修改 generateStyleCode 函数，使其能够正确处理 src 属性。

修改后的 generateStyleCode 函数如下：

// 根据compiler组合成style标签字符串代码
```
const generateStyleCode = (styles: any[]) =>
  styles.reduce((str, item, _i) => {
    // 构建属性字符串
    let attrs = '';
    if (item.lang) attrs += ` lang='${item.lang}'`;
    if (item.scoped) attrs += ` scoped`; // scoped 是布尔属性，不需要值
    if (item.src) attrs += ` src='${item.src}'`; // 关键：添加对 src 属性的支持

    // 根据是否有 src 属性来决定如何生成标签
    if (item.src) {
      // 如果有 src，则生成自闭合标签或空标签，Vite 会根据 src 去加载文件
      return str + `<style${attrs}></style>\n`;
    } else {
      // 如果没有 src，则将 content 作为标签体
      return str + `<style${attrs}>\n${item.content}\n</style>\n`;
    }
  }, '');
```
修改说明
提取属性构建：将 lang、scoped 和新增的 src 属性的构建逻辑集中在一起，使代码更清晰。
处理 src 属性：如果 item.src 存在，就将其添加到属性字符串 attrs 中。
分支处理：
如果 item.src 存在，生成一个没有内容体的 <style> 标签（<style ...></style>）。Vite 的核心机制会识别这个 src 属性，并自动去加载和处理 ./index.scss 文件，最终将编译后的 CSS 注入到页面中。
如果 item.src 不存在，则按原逻辑，将 item.content 作为标签体内容。